### PR TITLE
Overlay satellites when reading from multi-field (multi-zenith) ms

### DIFF
--- a/bin/disko
+++ b/bin/disko
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 
 import argparse
 import datetime
+import time
 import json
 import logging
 from copy import deepcopy
@@ -52,6 +53,7 @@ if __name__ == '__main__':
     data_group = parser.add_mutually_exclusive_group()
     data_group.add_argument('--file', required=False, default=None, help="Snapshot observation saved JSON file (visiblities, positions and more).")
     data_group.add_argument('--ms', required=False, default=None, help="visibility file")
+    parser.add_argument('--sourcesdb', required=False, nargs="*", help="Reads sources from a JSON file (or sets of files)")
     
     parser.add_argument('--nvis', type=int, default=1000, help="Number of visibilities to use.")
     parser.add_argument('--vis', required=False, default=None, help="Use a local JSON file containing the visibilities to create the image.")
@@ -131,6 +133,13 @@ if __name__ == '__main__':
         
         sphere = create_fov(ARGS.nside, fov=fov, res=res)
 
+    if ARGS.file and ARGS.ms:
+        raise RuntimeError("Input visibilities must be either from file (JSON) or from ms (CASA MSv2.0) format. "
+                           "Both not supported at present.")
+
+    if ARGS.sourcesdb and not ARGS.ms:
+        raise RuntimeError("Argument 'sourcesdb' may only be used when reading from MS")
+
     if ARGS.file:
         logger.info("Getting Data from file: {}".format(ARGS.file))
         # Load data from a JSON file
@@ -162,12 +171,24 @@ if __name__ == '__main__':
         if not os.path.exists(ARGS.ms):
             raise RuntimeError(f"Measurement set {ARGS.ms} not found")
 
+        sources_json = {}
+        if ARGS.sourcesdb:
+            logger.info(f"Fetching sources from file: ")
+            for s in ARGS.sourcesdb:
+                logger.info(f"\t '{s}'")
+                with open(s, 'r') as json_file:
+                    calib_info = json.load(json_file)
+                for d in calib_info['data']:
+                    vis_json, source_json = d
+                    timestamp = vis_json['timestamp']
+                    sources_json.setdefault(datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ"), 
+                                            {'db': source_json})
+
         min_res = sphere.min_res()
         logger.info(f"Min Res {min_res}")
         disko = DiSkO.from_ms(ARGS.ms, ARGS.nvis, res=min_res, channel=ARGS.channel, field_id=ARGS.field, ddid=ARGS.ddid)
         # Convert from reduced Julian Date to timestamp.
         timestamp = disko.timestamp
-        
     else:
         logger.info("Getting Data from API: {}".format(ARGS.api))
 
@@ -198,11 +219,38 @@ if __name__ == '__main__':
     time_repr = "{:%Y_%m_%d_%H_%M_%S_%Z}".format(timestamp)
 
     # Processing
-    
+
+    # CASAcore UVW is conjugated, so to make things consistent with data
+    # streaming off telescope we need the vis flipped about
+    if ARGS.ms:
+        disko.vis_arr = disko.vis_arr.conjugate()
+    elif ARGS.file:
+        pass
+    else:
+        pass
     
     if ARGS.show_sources:
-        src_list = get_source_list(source_json, el_limit=ARGS.elevation, jy_limit=1e4)
-    
+        if ARGS.ms:
+            if ARGS.sourcesdb:
+                ctr_timestamp = time.mktime(timestamp.timetuple())
+                timestamps = np.array(list(map(lambda x: time.mktime(x.timetuple()), sources_json.keys())))
+                if timestamps.size == 0:
+                    logger.critical("No sources exist from provided sourcesdb file. Will not be able to overplot sources")
+                    src_list = None
+                else:
+                    sel = np.argmin(np.abs(timestamps - ctr_timestamp))
+                    sel_timestamp = list(sources_json.keys())[sel]
+                    logger.info(f"Will use source information at '{timestamps[sel]}' as the closest matching timestamp to the "
+                                f"imaging centroid '{ctr_timestamp}'. The offset is {abs(timestamps[sel] - ctr_timestamp):.3f}s")
+                    source_json = sources_json[sel_timestamp]['db']
+                    src_list = get_source_list(source_json, el_limit=ARGS.elevation, jy_limit=1e4)
+            else:
+                logger.critical("You have requested sources to be overplotted but you have not provided sources databases to augment"
+                                "data loading from MSv2.0. Please load in sources via 'sourcesdb' parameter.")
+                src_list = None
+        else:
+            src_list = get_source_list(source_json, el_limit=ARGS.elevation, jy_limit=1e4)
+
     if ARGS.lasso:
         logger.info("L1 regularization alpha=%f" %ARGS.alpha)
         sky = disko.image_lasso(disko.vis_arr, sphere, alpha=ARGS.alpha, l1_ratio=ARGS.l1_ratio, scale=False, use_cv=ARGS.cv)

--- a/disko/ms_helper.py
+++ b/disko/ms_helper.py
@@ -189,7 +189,7 @@ def read_ms(ms, num_vis, angular_resolution, chunks=1000, channel=0, field_id=0,
                     ds.DATA.data[indices, channel, pol], "DATA", dtype=np.complex64
                 )
 
-                epoch_seconds = np.array(ds.TIME.data)[0]
+                epoch_seconds = np.mean(np.array(ds.TIME.data))
         if no_datasets_read == 0:
             raise RuntimeError("FIELD_ID ({}) or DDID ({}) contains no data".format(field_id, ddid))
 


### PR DESCRIPTION
- Fixes #5
- This changes handedness for databases written by tart2ms (casacore -- accepted NRAO convention)
- Applies telescope convention for JSON data
- Change timestamp to mean epoch for FITS header information
- Add switch to load in GNSS source position from JSON files until such time we read them from MS. NN interpolation is used to get the positions plotted for the field