### PR TITLE
Fix backwards transform operator handedness when going from casacore UVW

### DIFF
--- a/bin/disko
+++ b/bin/disko
@@ -198,7 +198,15 @@ if __name__ == '__main__':
     time_repr = "{:%Y_%m_%d_%H_%M_%S_%Z}".format(timestamp)
 
     # Processing
-    
+
+    # CASAcore UVW is conjugated, so to make things consistent with data
+    # streaming off telescope we need the vis flipped about
+    if ARGS.ms:
+        disko.vis_arr = disko.vis_arr.conjugate()
+    elif ARGS.file:
+        pass
+    else:
+        pass
     
     if ARGS.show_sources:
         src_list = get_source_list(source_json, el_limit=ARGS.elevation, jy_limit=1e4)


### PR DESCRIPTION
This fixes the handedness convention on UVW when going from casacore based UVW to the accepted convention (NRAO)

Closes #8